### PR TITLE
Fixed decryptAndSetPassword to avoid NPE on entries without password

### DIFF
--- a/src/main/java/de/slackspace/openkeepass/parser/KeePassDatabaseXmlParser.java
+++ b/src/main/java/de/slackspace/openkeepass/parser/KeePassDatabaseXmlParser.java
@@ -32,7 +32,7 @@ public class KeePassDatabaseXmlParser {
 	}
 	
 	private void decryptAndSetPassword(Entry entry, ProtectedStringCrypto protectedStringCrypto) {
-		if(entry != null && !entry.getPassword().isEmpty() && entry.isPasswordProtected()) {
+		if(entry != null && entry.getPassword() != null && !entry.getPassword().isEmpty() && entry.isPasswordProtected()) {
 			String decrypted = protectedStringCrypto.decrypt(entry.getPassword());
 			entry.setPassword(decrypted);
 		}


### PR DESCRIPTION
Hi,

While running the code that iterates through all entries and displays the password I received a NullPointException when executing "entry.getPassword().isEmpty()". The reason was a forgotten entry without password so "entry.getPassword()"  was null.

I added an additional null verification before the password decrypt.

Cheers,