### PR TITLE
changed entrybuilder to allow initialization with a given UUID

### DIFF
--- a/src/main/java/de/slackspace/openkeepass/domain/EntryBuilder.java
+++ b/src/main/java/de/slackspace/openkeepass/domain/EntryBuilder.java
@@ -21,7 +21,11 @@ public class EntryBuilder {
 	public EntryBuilder() {
 		this.uuid = UUID.randomUUID();
 	}
-	
+
+	public EntryBuilder (UUID uuid) {
+		this.uuid = uuid;
+	}
+
 	public EntryBuilder(String title) {
 		this();
 		this.title = title;
@@ -31,7 +35,12 @@ public class EntryBuilder {
 		this.title = title;
 		return this;
 	}
-	
+
+	public EntryBuilder uuid(UUID uuid) {
+		this.uuid = uuid;
+		return this;
+	}
+
 	public EntryBuilder username(String username) {
 		this.username = username;
 		return this;


### PR DESCRIPTION
Tools like keepasshttp (used by chromipass and foxipass) need to initialize an entry with a specific UUID.
This commit adds that.