### PR TITLE
GroupIterator in GroupZipper doesn't go up correctly

### DIFF
--- a/src/main/java/de/slackspace/openkeepass/domain/zipper/GroupZipper.java
+++ b/src/main/java/de/slackspace/openkeepass/domain/zipper/GroupZipper.java
@@ -30,7 +30,7 @@ public class GroupZipper {
 
 	/**
 	 * Create a zipper with the tree structure of the given KeePass file.
-	 * 
+	 *
 	 * @param keePassFile
 	 *            the underlying data structure
 	 */
@@ -47,7 +47,7 @@ public class GroupZipper {
 
 	/**
 	 * Returns true if it is possible to navigate down.
-	 * 
+	 *
 	 * @return true, if it is possible to navigate down
 	 */
 	public boolean canDown() {
@@ -62,7 +62,7 @@ public class GroupZipper {
 	 * Navigates down the tree to the first child node of the current node.
 	 * <p>
 	 * If the current node has no childs an exception will be thrown.
-	 * 
+	 *
 	 * @return
 	 * @throws RuntimeException
 	 *             if the current node has no child nodes
@@ -81,7 +81,7 @@ public class GroupZipper {
 
 	/**
 	 * Returns true if it is possible to navigate up.
-	 * 
+	 *
 	 * @return true, if it is possible to navigate up
 	 */
 	public boolean canUp() {
@@ -96,7 +96,7 @@ public class GroupZipper {
 	 * Navigates up the tree to the parent node of the current node.
 	 * <p>
 	 * If the current node has no parent an exception will be thrown.
-	 * 
+	 *
 	 * @return
 	 * @throws RuntimeException
 	 *             if the current node has no parent node
@@ -115,7 +115,7 @@ public class GroupZipper {
 
 	/**
 	 * Returns true if it is possible to navigate right.
-	 * 
+	 *
 	 * @return true, if it is possible to navigate right
 	 */
 	public boolean canRight() {
@@ -132,7 +132,7 @@ public class GroupZipper {
 
 	/**
 	 * Navigates right the tree to the next node at the same level.
-	 * 
+	 *
 	 * @return
 	 */
 	public GroupZipper right() {
@@ -149,7 +149,7 @@ public class GroupZipper {
 
 	/**
 	 * Returns true if it is possible to navigate left.
-	 * 
+	 *
 	 * @return true, if it is possible to navigate left
 	 */
 	public boolean canLeft() {
@@ -162,7 +162,7 @@ public class GroupZipper {
 
 	/**
 	 * Navigates left the tree to the previous node at the same level.
-	 * 
+	 *
 	 * @return
 	 */
 	public GroupZipper left() {
@@ -181,7 +181,7 @@ public class GroupZipper {
 	 * Returns the current node. This can be seen as a pointer to the current
 	 * element in the tree.
 	 * <p>
-	 * 
+	 *
 	 * @return
 	 */
 	public Group getNode() {
@@ -192,7 +192,7 @@ public class GroupZipper {
 	 * Replaces the current node with the given one.
 	 * <p>
 	 * Can be used to modify the tree.
-	 * 
+	 *
 	 * @param group
 	 *            the replacement node
 	 * @return
@@ -209,7 +209,7 @@ public class GroupZipper {
 
 	/**
 	 * Returns a new {@link KeePassFile} from the current tree structure.
-	 * 
+	 *
 	 * @return a new KeePass file
 	 */
 	public KeePassFile close() {
@@ -220,7 +220,7 @@ public class GroupZipper {
 
 	/**
 	 * Returns the root node of the tree.
-	 * 
+	 *
 	 * @return the root node of the tree
 	 */
 	public Group getRoot() {
@@ -233,7 +233,7 @@ public class GroupZipper {
 
 	/**
 	 * Replaces the meta with the given one.
-	 * 
+	 *
 	 * @param meta
 	 *            the given meta object
 	 * @return
@@ -250,7 +250,7 @@ public class GroupZipper {
 
 	/**
 	 * Returns an iterator over the groups in this tree.
-	 * 
+	 *
 	 * @return an iterator to iterate through the tree
 	 */
 	public Iterator<Group> iterator() {
@@ -263,7 +263,7 @@ public class GroupZipper {
 
 		/**
 		 * Checks if it is possible for any parent node to go right in the tree.
-		 * 
+		 *
 		 */
 		private boolean canGoRightAtAnyLevel(GroupZipper parent) {
 			if (parent == null) {
@@ -285,7 +285,7 @@ public class GroupZipper {
 			if (parent.canRight()) {
 				return up().right().getNode();
 			} else {
-				return getNextRightNode(up());
+				return getNextRightNode(parent.up());
 			}
 		}
 

--- a/src/test/java/de/slackspace/openkeepass/domain/GroupZipperTest.java
+++ b/src/test/java/de/slackspace/openkeepass/domain/GroupZipperTest.java
@@ -33,7 +33,7 @@ public class GroupZipperTest {
 	private KeePassFile createTreeStructure() {
 		/*
 		 * Should create the following structure:
-		 * 
+		 *
 		 * Root | |-- First entry (E) |-- Banking (G) | |-- Internet (G) | |--
 		 * Shopping (G) |-- Second entry (E) | |-- Stores (G) | |-- Music (G)
 		 */
@@ -125,6 +125,58 @@ public class GroupZipperTest {
 		}
 
 		Assert.assertEquals(6, visitedGroups.size());
+	}
+
+	@Test
+	public void shouldVisitAllDeeplyNestedNodes() {
+		Group rootA = new GroupBuilder("A")
+			.addGroup(new GroupBuilder("B")
+				.addGroup(new GroupBuilder("C")
+					.addGroup(new GroupBuilder("D").build())
+					.addGroup(new GroupBuilder("E").build())
+					.build()
+				)
+				.addGroup(new GroupBuilder("F").build())
+				.addGroup(new GroupBuilder("G")
+					.addGroup(new GroupBuilder("H")
+						.addGroup(new GroupBuilder("I")
+							.addGroup(new GroupBuilder("J").build())
+							.build()
+						)
+						.addGroup(new GroupBuilder("K").build())
+						.build()
+					)
+					.addGroup(new GroupBuilder("L").build())
+					.build()
+				)
+				.build()
+			)
+			.addGroup(new GroupBuilder("M").build())
+			.addGroup(new GroupBuilder("N")
+				.addGroup(new GroupBuilder("O")
+					.addGroup(new GroupBuilder("P")
+						.addGroup(new GroupBuilder("Q").build())
+						.build()
+					)
+					.build()
+				)
+				.addGroup(new GroupBuilder("R").build())
+				.addGroup(new GroupBuilder("S")
+					.addGroup(new GroupBuilder("T").build())
+					.build()
+				)
+				.build()
+			)
+			.build();
+		KeePassFile db = new KeePassFileBuilder("deepTest").addTopGroups(rootA).build();
+		GroupZipper zipper = new GroupZipper(db);
+		Iterator<Group> iterator = zipper.iterator();
+		StringBuilder sb = new StringBuilder();
+		while (iterator.hasNext()) {
+			Group next = iterator.next();
+			sb.append(next.getName());
+		}
+		Assert.assertEquals("ABCDEFGHIJKLMNOPQRST", sb.toString());
 	}
 
 	private KeePassFile createFlatGroupStructure() {


### PR DESCRIPTION
The iterator threw an exception on a KeePass file with a 3 level deep nesting of groups.
Basically on something that looked like
```
Root
> A
  > B
    > C
> D
```
it would choke after it had visited C.
> Could not move right because the last node at this level has already been reached

I dug deep into GroupZipper and after much testing found the problem: when recursing, `getNextRightNode` calls `up()` but it needs to use `parent.up()`. That is, because the next call needs the next parent, `up()` just returns the same thing that's already in the `parent` parameter.
```java
private Group getNextRightNode(GroupZipper parent) {
  // ...
  return getNextRightNode(parent.up()); // was just (up())
}
```
This is now analogous to how `canGoRightAtAnyLevel` already does it:
```java
private boolean canGoRightAtAnyLevel(GroupZipper parent) {
  // ...
  return canGoRightAtAnyLevel(parent.parent);
}
```

I also added a new test for deeply nested groups.

P.S.: I guess the removal of those spaces in the diff is due to the .editorconfig setting `trim_trailing_whitespace = true`.