### PR TITLE
Custom icon builder support

### DIFF
--- a/src/main/java/de/slackspace/openkeepass/domain/CustomIcon.java
+++ b/src/main/java/de/slackspace/openkeepass/domain/CustomIcon.java
@@ -26,6 +26,14 @@ public class CustomIcon {
 	@XmlElement(name = "Data")
 	private byte[] data;
 
+	CustomIcon() {
+	}
+
+	public CustomIcon(CustomIconBuilder customIconBuilder) {
+		this.uuid = customIconBuilder.uuid;
+		this.data = customIconBuilder.data;
+	}
+
 	/**
 	 * Returns the uuid of this custom icon.
 	 *

--- a/src/main/java/de/slackspace/openkeepass/domain/CustomIconBuilder.java
+++ b/src/main/java/de/slackspace/openkeepass/domain/CustomIconBuilder.java
@@ -1,0 +1,41 @@
+package de.slackspace.openkeepass.domain;
+
+import java.util.UUID;
+
+/**
+ * A builder to create {@link CustomIcon} objects.
+ *
+ */
+public class CustomIconBuilder {
+
+	UUID uuid;
+
+	byte[] data;
+
+	public CustomIconBuilder() {
+	}
+
+	public CustomIconBuilder(CustomIcon customIcon) {
+		this.uuid = customIcon.getUuid();
+		this.data = customIcon.getData();
+	}
+
+	public CustomIconBuilder uuid(UUID uuid) {
+		this.uuid = uuid;
+		return this;
+	}
+
+	public CustomIconBuilder data(byte[] data) {
+		this.data = data;
+		return this;
+	}
+
+	/**
+	 * Builds a new custom icon with the values from the builder.
+	 *
+	 * @return a new CustomIcon object
+	 */
+	public CustomIcon build() {
+		return new CustomIcon(this);
+	}
+}

--- a/src/main/java/de/slackspace/openkeepass/domain/CustomIcons.java
+++ b/src/main/java/de/slackspace/openkeepass/domain/CustomIcons.java
@@ -19,6 +19,13 @@ public class CustomIcons {
 	@XmlElement(name = "Icon")
 	private List<CustomIcon> customIcons = new ArrayList<CustomIcon>();
 
+	CustomIcons() {
+	}
+
+	public CustomIcons(CustomIconsBuilder customIconsBuilder) {
+		this.customIcons = customIconsBuilder.customIcons;
+	}
+
 	/**
 	 * Returns all custom icons found inside the database.
 	 *

--- a/src/main/java/de/slackspace/openkeepass/domain/CustomIconsBuilder.java
+++ b/src/main/java/de/slackspace/openkeepass/domain/CustomIconsBuilder.java
@@ -1,0 +1,33 @@
+package de.slackspace.openkeepass.domain;
+
+import java.util.List;
+
+/**
+ * A builder to create {@link CustomIcons} objects.
+ *
+ */
+public class CustomIconsBuilder {
+
+	List<CustomIcon> customIcons;
+
+	public CustomIconsBuilder() {
+	}
+
+	public CustomIconsBuilder(CustomIcons customIcons) {
+		this.customIcons = customIcons.getIcons();
+	}
+
+	public CustomIconsBuilder customIcons(List<CustomIcon> customIcons) {
+		this.customIcons = customIcons;
+		return this;
+	}
+
+	/**
+	 * Builds a new custom icons list with the values from the builder.
+	 *
+	 * @return a new CustomIcons object
+	 */
+	public CustomIcons build() {
+		return new CustomIcons(this);
+	}
+}

--- a/src/main/java/de/slackspace/openkeepass/domain/Entry.java
+++ b/src/main/java/de/slackspace/openkeepass/domain/Entry.java
@@ -54,6 +54,8 @@ public class Entry implements KeePassFileElement {
 		this.history = builder.history;
 		this.uuid = builder.uuid;
 		this.iconData = builder.iconData;
+		this.iconId = builder.iconId;
+		this.customIconUUID = builder.customIconUUID;
 
 		setValue(false, NOTES, builder.notes);
 		setValue(true, PASSWORD, builder.password);
@@ -163,7 +165,7 @@ public class Entry implements KeePassFileElement {
 
 	/**
 	 * Retrieves a property by it's name (ignores case)
-	 * 
+	 *
 	 * @param name
 	 *            the name of the property to find
 	 * @return the property if found, null otherwise

--- a/src/main/java/de/slackspace/openkeepass/domain/EntryBuilder.java
+++ b/src/main/java/de/slackspace/openkeepass/domain/EntryBuilder.java
@@ -26,7 +26,11 @@ public class EntryBuilder {
 
 	Entry originalEntry;
 
+	int iconId;
+
 	byte[] iconData;
+
+	UUID customIconUUID;
 
 	List<Property> customPropertyList = new ArrayList<Property>();
 
@@ -39,7 +43,7 @@ public class EntryBuilder {
 
 	/**
 	 * Creates a new builder with the given UUID.
-	 * 
+	 *
 	 * @param uuid
 	 *            the UUID which should be used
 	 */
@@ -49,7 +53,7 @@ public class EntryBuilder {
 
 	/**
 	 * Creates a new builder with the given title.
-	 * 
+	 *
 	 * @param title
 	 *            the title which should be used
 	 */
@@ -60,7 +64,7 @@ public class EntryBuilder {
 
 	/**
 	 * Initializes the builder with values from the given entry.
-	 * 
+	 *
 	 * @param entry
 	 *            the values from this will initialize the builder
 	 */
@@ -76,6 +80,9 @@ public class EntryBuilder {
 		this.password = entry.getPassword();
 		this.notes = entry.getNotes();
 		this.url = entry.getUrl();
+		this.iconId = entry.getIconId();
+		this.iconData = entry.getIconData();
+		this.customIconUUID = entry.getCustomIconUuid();
 		this.customPropertyList.addAll(entry.getCustomProperties());
 	}
 
@@ -114,19 +121,24 @@ public class EntryBuilder {
 		return this;
 	}
 
-	/**
-	 * WARNING: not yet completely implemented, will not write data into KeePass
-	 * file!
-	 * 
-	 */
 	public EntryBuilder iconData(byte[] iconData) {
 		this.iconData = iconData;
 		return this;
 	}
 
+	public EntryBuilder iconId(int iconId) {
+		this.iconId = iconId;
+		return this;
+	}
+
+	public EntryBuilder customIconUuid(UUID uuid) {
+		this.customIconUUID = uuid;
+		return this;
+	}
+
 	/**
 	 * Builds a new entry with the values from the builder.
-	 * 
+	 *
 	 * @return a new entry
 	 */
 	public Entry build() {

--- a/src/main/java/de/slackspace/openkeepass/domain/Group.java
+++ b/src/main/java/de/slackspace/openkeepass/domain/Group.java
@@ -15,7 +15,7 @@ import de.slackspace.openkeepass.xml.UUIDXmlAdapter;
 
 /**
  * A Group represents a structure that consists of entries and subgroups.
- * 
+ *
  * @see Entry
  *
  */
@@ -65,11 +65,12 @@ public class Group implements KeePassFileElement {
 		times = builder.times;
 		uuid = builder.uuid;
 		iconData = builder.iconData;
+		customIconUUID = builder.customIconUuid;
 	}
 
 	/**
 	 * Retrieves the Uuid of this group.
-	 * 
+	 *
 	 * @return the Uuid of this group
 	 */
 	public UUID getUuid() {
@@ -78,7 +79,7 @@ public class Group implements KeePassFileElement {
 
 	/**
 	 * Retrieves the name of the group.
-	 * 
+	 *
 	 * @return the name of the group
 	 */
 	public String getName() {
@@ -87,7 +88,7 @@ public class Group implements KeePassFileElement {
 
 	/**
 	 * Retrieves all subgroups of this group.
-	 * 
+	 *
 	 * @return all subgroups of this group
 	 */
 	public List<Group> getGroups() {
@@ -96,7 +97,7 @@ public class Group implements KeePassFileElement {
 
 	/**
 	 * Retrieves all entries of this group.
-	 * 
+	 *
 	 * @return all entries of this group
 	 * @see Entry
 	 */
@@ -106,7 +107,7 @@ public class Group implements KeePassFileElement {
 
 	/**
 	 * Retrieves the entry with the given title.
-	 * 
+	 *
 	 * @param title
 	 *            the title of the entry which should be retrieved
 	 * @return an entry with matching title
@@ -127,7 +128,7 @@ public class Group implements KeePassFileElement {
 
 	/**
 	 * Retrieves the icon of this group.
-	 * 
+	 *
 	 * @return the icon of this group
 	 */
 	public int getIconId() {
@@ -159,7 +160,7 @@ public class Group implements KeePassFileElement {
 
 	/**
 	 * Retrieves the last expanded status of the group.
-	 * 
+	 *
 	 * @return true if the group was expanded the last time it was opened in
 	 *         keepass
 	 */

--- a/src/main/java/de/slackspace/openkeepass/domain/GroupBuilder.java
+++ b/src/main/java/de/slackspace/openkeepass/domain/GroupBuilder.java
@@ -18,6 +18,8 @@ public class GroupBuilder {
 
 	byte[] iconData;
 
+	UUID customIconUuid;
+
 	List<Entry> entries = new ArrayList<Entry>();
 
 	List<Group> groups = new ArrayList<Group>();
@@ -39,6 +41,8 @@ public class GroupBuilder {
 		this.uuid = group.getUuid();
 		this.name = group.getName();
 		this.iconId = group.getIconId();
+		this.iconData = group.getIconData();
+		this.customIconUuid = group.getCustomIconUuid();
 		this.times = group.getTimes();
 		this.isExpanded = group.isExpanded();
 		this.groups = group.getGroups();
@@ -55,13 +59,13 @@ public class GroupBuilder {
 		return this;
 	}
 
-	/**
-	 * WARNING: not yet completely implemented, will not write data into KeePass
-	 * file!
-	 * 
-	 */
 	public GroupBuilder iconData(byte[] iconData) {
 		this.iconData = iconData;
+		return this;
+	}
+
+	public GroupBuilder customIconUuid(UUID uuid) {
+		this.customIconUuid = uuid;
 		return this;
 	}
 

--- a/src/main/java/de/slackspace/openkeepass/domain/Meta.java
+++ b/src/main/java/de/slackspace/openkeepass/domain/Meta.java
@@ -15,7 +15,7 @@ import de.slackspace.openkeepass.xml.UUIDXmlAdapter;
 /**
  * Represents the metadata of the KeePass database like database name, custom
  * icons or how much history entries will be preserved.
- * 
+ *
  */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -74,6 +74,7 @@ public class Meta {
 		this.recycleBinChanged = metaBuilder.recycleBinChanged;
 		this.recycleBinEnabled = metaBuilder.recycleBinEnabled;
 		this.recycleBinUuid = metaBuilder.recycleBinUuid;
+		this.customIcons = metaBuilder.customIcons;
 	}
 
 	public String getDatabaseName() {

--- a/src/main/java/de/slackspace/openkeepass/domain/MetaBuilder.java
+++ b/src/main/java/de/slackspace/openkeepass/domain/MetaBuilder.java
@@ -31,9 +31,11 @@ public class MetaBuilder {
 
 	long historyMaxSize;
 
+	CustomIcons customIcons;
+
 	/**
 	 * Creates a new builder with the given database name.
-	 * 
+	 *
 	 * @param databaseName
 	 *            the name which should be used
 	 */
@@ -43,7 +45,7 @@ public class MetaBuilder {
 
 	/**
 	 * Initializes the builder with values from the given meta.
-	 * 
+	 *
 	 * @param meta
 	 *            the values from this will initialize the builder
 	 */
@@ -59,6 +61,7 @@ public class MetaBuilder {
 		this.recycleBinChanged = meta.getRecycleBinChanged();
 		this.historyMaxItems = meta.getHistoryMaxItems();
 		this.historyMaxSize = meta.getHistoryMaxSize();
+		this.customIcons = meta.getCustomIcons();
 	}
 
 	public MetaBuilder databaseName(String databaseName) {
@@ -116,9 +119,14 @@ public class MetaBuilder {
 		return this;
 	}
 
+	public MetaBuilder customIcons(CustomIcons customIcons) {
+		this.customIcons = customIcons;
+		return this;
+	}
+
 	/**
 	 * Builds a new meta with the values from the builder.
-	 * 
+	 *
 	 * @return a new meta object
 	 */
 	public Meta build() {

--- a/src/test/java/de/slackspace/openkeepass/enricher/IconEnricherTest.java
+++ b/src/test/java/de/slackspace/openkeepass/enricher/IconEnricherTest.java
@@ -1,0 +1,45 @@
+package de.slackspace.openkeepass.enricher;
+
+import de.slackspace.openkeepass.domain.*;
+import de.slackspace.openkeepass.domain.enricher.IconEnricher;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.xml.bind.DatatypeConverter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class IconEnricherTest {
+
+	@Test
+	public void shouldAddIconDataAndMaintainIconUuid() {
+		UUID iconUuid = UUID.randomUUID();
+		byte[] transparentPng = DatatypeConverter.parseBase64Binary(
+			"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII="
+		);
+
+		CustomIcon customIcon = new CustomIconBuilder().uuid(iconUuid).data(transparentPng).build();
+
+		List<CustomIcon> customIconList = new ArrayList<CustomIcon>();
+		customIconList.add(customIcon);
+
+		CustomIcons customIcons = new CustomIconsBuilder().customIcons(customIconList).build();
+
+		Meta meta = new MetaBuilder("iconTest").customIcons(customIcons).build();
+
+		Entry entry1 = new EntryBuilder("1").customIconUuid(iconUuid).build();
+
+		Group groupA = new GroupBuilder("A").customIconUuid(iconUuid).addEntry(entry1).build();
+
+		KeePassFile keePassFile = new KeePassFileBuilder(meta).addTopGroups(groupA).build();
+		IconEnricher enricher = new IconEnricher();
+		KeePassFile enrichedKeePassFile = enricher.enrichNodesWithIconData(keePassFile);
+
+		Assert.assertEquals("group UUID doesn't match", iconUuid, enrichedKeePassFile.getRoot().getGroups().get(0).getCustomIconUuid());
+		Assert.assertArrayEquals("group icon data doesn't match", transparentPng, enrichedKeePassFile.getRoot().getGroups().get(0).getIconData());
+
+		Assert.assertEquals("entry UUID doesn't match", iconUuid, enrichedKeePassFile.getRoot().getGroups().get(0).getEntries().get(0).getCustomIconUuid());
+		Assert.assertArrayEquals("entry icon data doesn't match", transparentPng, enrichedKeePassFile.getRoot().getGroups().get(0).getEntries().get(0).getIconData());
+	}
+}


### PR DESCRIPTION
Hey, me again. ;)

I noticed that the `customIconUuid` of my groups / entries was null after the `IconEnricher` had done its job (`iconData` was filled correctly, though).

So what started as a fix for this, step by step turned into a first version of full builder / write support for (custom) icons. Whoops.

I also added a test, but I guess it needs to be split up now. Writing a database to disk and opening it in KeePass looked okay, btw - the custom icons were there.

Let me know what you think / what needs to be changed or if I totally went the wrong way with this.

Getting some sleep now. :zzz: