### PR TITLE
multiple code improvements: squid:S00105, squid:S2184

### DIFF
--- a/src/main/java/de/slackspace/openkeepass/KeePassDatabase.java
+++ b/src/main/java/de/slackspace/openkeepass/KeePassDatabase.java
@@ -86,400 +86,400 @@ import de.slackspace.openkeepass.xml.KeyFileXmlParser;
  */
 public class KeePassDatabase {
 
-	private static final String UTF_8 = "UTF-8";
-	private static final String MSG_UTF8_NOT_SUPPORTED = "The encoding UTF-8 is not supported";
-	private static final String MSG_EMPTY_MASTER_KEY = "The password for the database must not be null. Please provide a valid password.";
+    private static final String UTF_8 = "UTF-8";
+    private static final String MSG_UTF8_NOT_SUPPORTED = "The encoding UTF-8 is not supported";
+    private static final String MSG_EMPTY_MASTER_KEY = "The password for the database must not be null. Please provide a valid password.";
 
-	private KeePassHeader keepassHeader = new KeePassHeader();
-	private byte[] keepassFile;
+    private KeePassHeader keepassHeader = new KeePassHeader();
+    private byte[] keepassFile;
 
-	protected Decrypter decrypter = new Decrypter();
-	protected KeePassDatabaseXmlParser keePassDatabaseXmlParser = new KeePassDatabaseXmlParser();
-	protected KeyFileXmlParser keyFileXmlParser = new KeyFileXmlParser();
+    protected Decrypter decrypter = new Decrypter();
+    protected KeePassDatabaseXmlParser keePassDatabaseXmlParser = new KeePassDatabaseXmlParser();
+    protected KeyFileXmlParser keyFileXmlParser = new KeyFileXmlParser();
 
-	private KeePassDatabase(InputStream inputStream) {
-		try {
-			keepassFile = StreamUtils.toByteArray(inputStream);
-			keepassHeader.checkVersionSupport(keepassFile);
-			keepassHeader.read(keepassFile);
-		} catch (IOException e) {
-			throw new KeePassDatabaseUnreadable("Could not open database file", e);
-		}
-	}
+    private KeePassDatabase(InputStream inputStream) {
+        try {
+            keepassFile = StreamUtils.toByteArray(inputStream);
+            keepassHeader.checkVersionSupport(keepassFile);
+            keepassHeader.read(keepassFile);
+        } catch (IOException e) {
+            throw new KeePassDatabaseUnreadable("Could not open database file", e);
+        }
+    }
 
-	/**
-	 * Retrieves a KeePassDatabase instance. The instance returned is based on
-	 * the given database filename and tries to parse the database header of it.
-	 *
-	 * @param keePassDatabaseFile
-	 *            a KeePass database filename, must not be NULL
-	 * @return a KeePassDatabase
-	 */
-	public static KeePassDatabase getInstance(String keePassDatabaseFile) {
-		return getInstance(new File(keePassDatabaseFile));
-	}
+    /**
+     * Retrieves a KeePassDatabase instance. The instance returned is based on
+     * the given database filename and tries to parse the database header of it.
+     *
+     * @param keePassDatabaseFile
+     *            a KeePass database filename, must not be NULL
+     * @return a KeePassDatabase
+     */
+    public static KeePassDatabase getInstance(String keePassDatabaseFile) {
+        return getInstance(new File(keePassDatabaseFile));
+    }
 
-	/**
-	 * Retrieves a KeePassDatabase instance. The instance returned is based on
-	 * the given database file and tries to parse the database header of it.
-	 *
-	 * @param keePassDatabaseFile
-	 *            a KeePass database file, must not be NULL
-	 * @return a KeePassDatabase
-	 */
-	public static KeePassDatabase getInstance(File keePassDatabaseFile) {
-		if (keePassDatabaseFile == null) {
-			throw new IllegalArgumentException("You must provide a valid KeePass database file.");
-		}
+    /**
+     * Retrieves a KeePassDatabase instance. The instance returned is based on
+     * the given database file and tries to parse the database header of it.
+     *
+     * @param keePassDatabaseFile
+     *            a KeePass database file, must not be NULL
+     * @return a KeePassDatabase
+     */
+    public static KeePassDatabase getInstance(File keePassDatabaseFile) {
+        if (keePassDatabaseFile == null) {
+            throw new IllegalArgumentException("You must provide a valid KeePass database file.");
+        }
 
-		InputStream keePassDatabaseStream = null;
-		try {
-			keePassDatabaseStream = new FileInputStream(keePassDatabaseFile);
-			return getInstance(keePassDatabaseStream);
-		} catch (FileNotFoundException e) {
-			throw new IllegalArgumentException(
-					"The KeePass database file could not be found. You must provide a valid KeePass database file.", e);
-		} finally {
-			if (keePassDatabaseStream != null) {
-				try {
-					keePassDatabaseStream.close();
-				} catch (IOException e) {
-					// Ignore
-				}
-			}
-		}
-	}
+        InputStream keePassDatabaseStream = null;
+        try {
+            keePassDatabaseStream = new FileInputStream(keePassDatabaseFile);
+            return getInstance(keePassDatabaseStream);
+        } catch (FileNotFoundException e) {
+            throw new IllegalArgumentException(
+                    "The KeePass database file could not be found. You must provide a valid KeePass database file.", e);
+        } finally {
+            if (keePassDatabaseStream != null) {
+                try {
+                    keePassDatabaseStream.close();
+                } catch (IOException e) {
+                    // Ignore
+                }
+            }
+        }
+    }
 
-	/**
-	 * Retrieves a KeePassDatabase instance. The instance returned is based on
-	 * the given input stream and tries to parse the database header of it.
-	 *
-	 * @param keePassDatabaseStream
-	 *            an input stream of a KeePass database, must not be NULL
-	 * @return a KeePassDatabase
-	 */
-	public static KeePassDatabase getInstance(InputStream keePassDatabaseStream) {
-		if (keePassDatabaseStream == null) {
-			throw new IllegalArgumentException("You must provide a non-empty KeePass database stream.");
-		}
+    /**
+     * Retrieves a KeePassDatabase instance. The instance returned is based on
+     * the given input stream and tries to parse the database header of it.
+     *
+     * @param keePassDatabaseStream
+     *            an input stream of a KeePass database, must not be NULL
+     * @return a KeePassDatabase
+     */
+    public static KeePassDatabase getInstance(InputStream keePassDatabaseStream) {
+        if (keePassDatabaseStream == null) {
+            throw new IllegalArgumentException("You must provide a non-empty KeePass database stream.");
+        }
 
-		return new KeePassDatabase(keePassDatabaseStream);
-	}
+        return new KeePassDatabase(keePassDatabaseStream);
+    }
 
-	/**
-	 * Opens a KeePass database with the given password and returns the
-	 * KeePassFile for further processing.
-	 * <p>
-	 * If the database cannot be decrypted with the provided password an
-	 * exception will be thrown.
-	 *
-	 * @param password
-	 *            the password to open the database
-	 * @return a KeePassFile
-	 * @see KeePassFile
-	 */
-	public KeePassFile openDatabase(String password) {
-		if (password == null) {
-			throw new IllegalArgumentException(MSG_EMPTY_MASTER_KEY);
-		}
+    /**
+     * Opens a KeePass database with the given password and returns the
+     * KeePassFile for further processing.
+     * <p>
+     * If the database cannot be decrypted with the provided password an
+     * exception will be thrown.
+     *
+     * @param password
+     *            the password to open the database
+     * @return a KeePassFile
+     * @see KeePassFile
+     */
+    public KeePassFile openDatabase(String password) {
+        if (password == null) {
+            throw new IllegalArgumentException(MSG_EMPTY_MASTER_KEY);
+        }
 
-		try {
-			byte[] passwordBytes = password.getBytes(UTF_8);
-			byte[] hashedPassword = Sha256.hash(passwordBytes);
+        try {
+            byte[] passwordBytes = password.getBytes(UTF_8);
+            byte[] hashedPassword = Sha256.hash(passwordBytes);
 
-			return decryptAndParseDatabase(hashedPassword);
-		} catch (UnsupportedEncodingException e) {
-			throw new UnsupportedOperationException(MSG_UTF8_NOT_SUPPORTED, e);
-		}
-	}
+            return decryptAndParseDatabase(hashedPassword);
+        } catch (UnsupportedEncodingException e) {
+            throw new UnsupportedOperationException(MSG_UTF8_NOT_SUPPORTED, e);
+        }
+    }
 
-	/**
-	 * Opens a KeePass database with the given password and keyfile and returns
-	 * the KeePassFile for further processing.
-	 * <p>
-	 * If the database cannot be decrypted with the provided password and
-	 * keyfile an exception will be thrown.
-	 *
-	 * @param password
-	 *            the password to open the database
-	 * @param keyFile
-	 *            the password to open the database
-	 * @return a KeePassFile
-	 * @see KeePassFile
-	 */
-	public KeePassFile openDatabase(String password, File keyFile) {
-		if (password == null) {
-			throw new IllegalArgumentException(MSG_EMPTY_MASTER_KEY);
-		}
-		if (keyFile == null) {
-			throw new IllegalArgumentException("You must provide a valid KeePass keyfile.");
-		}
+    /**
+     * Opens a KeePass database with the given password and keyfile and returns
+     * the KeePassFile for further processing.
+     * <p>
+     * If the database cannot be decrypted with the provided password and
+     * keyfile an exception will be thrown.
+     *
+     * @param password
+     *            the password to open the database
+     * @param keyFile
+     *            the password to open the database
+     * @return a KeePassFile
+     * @see KeePassFile
+     */
+    public KeePassFile openDatabase(String password, File keyFile) {
+        if (password == null) {
+            throw new IllegalArgumentException(MSG_EMPTY_MASTER_KEY);
+        }
+        if (keyFile == null) {
+            throw new IllegalArgumentException("You must provide a valid KeePass keyfile.");
+        }
 
-		try {
-			return openDatabase(password, new FileInputStream(keyFile));
-		} catch (FileNotFoundException e) {
-			throw new IllegalArgumentException(
-					"The KeePass keyfile could not be found. You must provide a valid KeePass keyfile.", e);
-		}
-	}
+        try {
+            return openDatabase(password, new FileInputStream(keyFile));
+        } catch (FileNotFoundException e) {
+            throw new IllegalArgumentException(
+                    "The KeePass keyfile could not be found. You must provide a valid KeePass keyfile.", e);
+        }
+    }
 
-	/**
-	 * Opens a KeePass database with the given password and keyfile stream and
-	 * returns the KeePassFile for further processing.
-	 * <p>
-	 * If the database cannot be decrypted with the provided password and
-	 * keyfile stream an exception will be thrown.
-	 *
-	 * @param password
-	 *            the password to open the database
-	 * @param keyFileStream
-	 *            the keyfile to open the database as stream
-	 * @return a KeePassFile
-	 * @see KeePassFile
-	 */
-	public KeePassFile openDatabase(String password, InputStream keyFileStream) {
-		if (password == null) {
-			throw new IllegalArgumentException(MSG_EMPTY_MASTER_KEY);
-		}
-		if (keyFileStream == null) {
-			throw new IllegalArgumentException("You must provide a non-empty KeePass keyfile stream.");
-		}
+    /**
+     * Opens a KeePass database with the given password and keyfile stream and
+     * returns the KeePassFile for further processing.
+     * <p>
+     * If the database cannot be decrypted with the provided password and
+     * keyfile stream an exception will be thrown.
+     *
+     * @param password
+     *            the password to open the database
+     * @param keyFileStream
+     *            the keyfile to open the database as stream
+     * @return a KeePassFile
+     * @see KeePassFile
+     */
+    public KeePassFile openDatabase(String password, InputStream keyFileStream) {
+        if (password == null) {
+            throw new IllegalArgumentException(MSG_EMPTY_MASTER_KEY);
+        }
+        if (keyFileStream == null) {
+            throw new IllegalArgumentException("You must provide a non-empty KeePass keyfile stream.");
+        }
 
-		try {
-			byte[] passwordBytes = password.getBytes(UTF_8);
-			byte[] hashedPassword = Sha256.hash(passwordBytes);
+        try {
+            byte[] passwordBytes = password.getBytes(UTF_8);
+            byte[] hashedPassword = Sha256.hash(passwordBytes);
 
-			KeyFile keyFile = keyFileXmlParser.fromXml(keyFileStream);
-			byte[] protectedBuffer = Base64.decode(keyFile.getKey().getData().getBytes(UTF_8));
-			if (protectedBuffer.length != 32) {
-				protectedBuffer = Sha256.hash(protectedBuffer);
-			}
+            KeyFile keyFile = keyFileXmlParser.fromXml(keyFileStream);
+            byte[] protectedBuffer = Base64.decode(keyFile.getKey().getData().getBytes(UTF_8));
+            if (protectedBuffer.length != 32) {
+                protectedBuffer = Sha256.hash(protectedBuffer);
+            }
 
-			return decryptAndParseDatabase(ByteUtils.concat(hashedPassword, protectedBuffer));
-		} catch (UnsupportedEncodingException e) {
-			throw new UnsupportedOperationException(MSG_UTF8_NOT_SUPPORTED, e);
-		}
-	}
+            return decryptAndParseDatabase(ByteUtils.concat(hashedPassword, protectedBuffer));
+        } catch (UnsupportedEncodingException e) {
+            throw new UnsupportedOperationException(MSG_UTF8_NOT_SUPPORTED, e);
+        }
+    }
 
-	/**
-	 * Opens a KeePass database with the given keyfile and returns the
-	 * KeePassFile for further processing.
-	 * <p>
-	 * If the database cannot be decrypted with the provided password an
-	 * exception will be thrown.
-	 *
-	 * @param keyFile
-	 *            the password to open the database
-	 * @return a KeePassFile the keyfile to open the database
-	 * @see KeePassFile
-	 */
-	public KeePassFile openDatabase(File keyFile) {
-		if (keyFile == null) {
-			throw new IllegalArgumentException("You must provide a valid KeePass keyfile.");
-		}
+    /**
+     * Opens a KeePass database with the given keyfile and returns the
+     * KeePassFile for further processing.
+     * <p>
+     * If the database cannot be decrypted with the provided password an
+     * exception will be thrown.
+     *
+     * @param keyFile
+     *            the password to open the database
+     * @return a KeePassFile the keyfile to open the database
+     * @see KeePassFile
+     */
+    public KeePassFile openDatabase(File keyFile) {
+        if (keyFile == null) {
+            throw new IllegalArgumentException("You must provide a valid KeePass keyfile.");
+        }
 
-		try {
-			return openDatabase(new FileInputStream(keyFile));
-		} catch (FileNotFoundException e) {
-			throw new IllegalArgumentException(
-					"The KeePass keyfile could not be found. You must provide a valid KeePass keyfile.", e);
-		}
-	}
+        try {
+            return openDatabase(new FileInputStream(keyFile));
+        } catch (FileNotFoundException e) {
+            throw new IllegalArgumentException(
+                    "The KeePass keyfile could not be found. You must provide a valid KeePass keyfile.", e);
+        }
+    }
 
-	/**
-	 * Opens a KeePass database with the given keyfile stream and returns the
-	 * KeePassFile for further processing.
-	 * <p>
-	 * If the database cannot be decrypted with the provided keyfile an
-	 * exception will be thrown.
-	 *
-	 * @param keyFileStream
-	 *            the keyfile to open the database as stream
-	 * @return a KeePassFile
-	 * @see KeePassFile
-	 */
-	public KeePassFile openDatabase(InputStream keyFileStream) {
-		if (keyFileStream == null) {
-			throw new IllegalArgumentException("You must provide a non-empty KeePass keyfile stream.");
-		}
+    /**
+     * Opens a KeePass database with the given keyfile stream and returns the
+     * KeePassFile for further processing.
+     * <p>
+     * If the database cannot be decrypted with the provided keyfile an
+     * exception will be thrown.
+     *
+     * @param keyFileStream
+     *            the keyfile to open the database as stream
+     * @return a KeePassFile
+     * @see KeePassFile
+     */
+    public KeePassFile openDatabase(InputStream keyFileStream) {
+        if (keyFileStream == null) {
+            throw new IllegalArgumentException("You must provide a non-empty KeePass keyfile stream.");
+        }
 
-		try {
-			KeyFile keyFile = keyFileXmlParser.fromXml(keyFileStream);
-			byte[] protectedBuffer = Base64.decode(keyFile.getKey().getData().getBytes(UTF_8));
+        try {
+            KeyFile keyFile = keyFileXmlParser.fromXml(keyFileStream);
+            byte[] protectedBuffer = Base64.decode(keyFile.getKey().getData().getBytes(UTF_8));
 
-			return decryptAndParseDatabase(protectedBuffer);
-		} catch (UnsupportedEncodingException e) {
-			throw new UnsupportedOperationException(MSG_UTF8_NOT_SUPPORTED, e);
-		}
-	}
+            return decryptAndParseDatabase(protectedBuffer);
+        } catch (UnsupportedEncodingException e) {
+            throw new UnsupportedOperationException(MSG_UTF8_NOT_SUPPORTED, e);
+        }
+    }
 
-	@SuppressWarnings("resource")
-	private KeePassFile decryptAndParseDatabase(byte[] key) {
-		try {
-			byte[] aesDecryptedDbFile = decrypter.decryptDatabase(key, keepassHeader, keepassFile);
+    @SuppressWarnings("resource")
+    private KeePassFile decryptAndParseDatabase(byte[] key) {
+        try {
+            byte[] aesDecryptedDbFile = decrypter.decryptDatabase(key, keepassHeader, keepassFile);
 
-			byte[] startBytes = new byte[32];
-			SafeInputStream decryptedStream = new SafeInputStream(new ByteArrayInputStream(aesDecryptedDbFile));
+            byte[] startBytes = new byte[32];
+            SafeInputStream decryptedStream = new SafeInputStream(new ByteArrayInputStream(aesDecryptedDbFile));
 
-			// Metadata must be skipped here
-			decryptedStream.skipSafe(KeePassHeader.VERSION_SIGNATURE_LENGTH + keepassHeader.getHeaderSize());
-			decryptedStream.readSafe(startBytes);
+            // Metadata must be skipped here
+            decryptedStream.skipSafe((long)KeePassHeader.VERSION_SIGNATURE_LENGTH + keepassHeader.getHeaderSize());
+            decryptedStream.readSafe(startBytes);
 
-			// Compare startBytes
-			if (!Arrays.equals(keepassHeader.getStreamStartBytes(), startBytes)) {
-				throw new KeePassDatabaseUnreadable(
-						"The keepass database file seems to be corrupt or cannot be decrypted.");
-			}
+            // Compare startBytes
+            if (!Arrays.equals(keepassHeader.getStreamStartBytes(), startBytes)) {
+                throw new KeePassDatabaseUnreadable(
+                        "The keepass database file seems to be corrupt or cannot be decrypted.");
+            }
 
-			HashedBlockInputStream hashedBlockInputStream = new HashedBlockInputStream(decryptedStream);
-			byte[] hashedBlockBytes = StreamUtils.toByteArray(hashedBlockInputStream);
+            HashedBlockInputStream hashedBlockInputStream = new HashedBlockInputStream(decryptedStream);
+            byte[] hashedBlockBytes = StreamUtils.toByteArray(hashedBlockInputStream);
 
-			byte[] decompressed = hashedBlockBytes;
+            byte[] decompressed = hashedBlockBytes;
 
-			// Unzip if necessary
-			if (keepassHeader.getCompression().equals(CompressionAlgorithm.Gzip)) {
-				GZIPInputStream gzipInputStream = new GZIPInputStream(new ByteArrayInputStream(hashedBlockBytes));
-				decompressed = StreamUtils.toByteArray(gzipInputStream);
-			}
+            // Unzip if necessary
+            if (keepassHeader.getCompression().equals(CompressionAlgorithm.Gzip)) {
+                GZIPInputStream gzipInputStream = new GZIPInputStream(new ByteArrayInputStream(hashedBlockBytes));
+                decompressed = StreamUtils.toByteArray(gzipInputStream);
+            }
 
-			ProtectedStringCrypto protectedStringCrypto;
-			if (keepassHeader.getCrsAlgorithm().equals(CrsAlgorithm.Salsa20)) {
-				protectedStringCrypto = Salsa20.createInstance(keepassHeader.getProtectedStreamKey());
-			} else {
-				throw new UnsupportedOperationException("Only Salsa20 is supported as CrsAlgorithm at the moment!");
-			}
+            ProtectedStringCrypto protectedStringCrypto;
+            if (keepassHeader.getCrsAlgorithm().equals(CrsAlgorithm.Salsa20)) {
+                protectedStringCrypto = Salsa20.createInstance(keepassHeader.getProtectedStreamKey());
+            } else {
+                throw new UnsupportedOperationException("Only Salsa20 is supported as CrsAlgorithm at the moment!");
+            }
 
-			KeePassFile unprocessedKeepassFile = keePassDatabaseXmlParser.fromXml(new ByteArrayInputStream(decompressed));
-			new ProtectedValueProcessor().processProtectedValues(new DecryptionStrategy(protectedStringCrypto), unprocessedKeepassFile);
-			return new IconEnricher().enrichNodesWithIconData(unprocessedKeepassFile);
-		} catch (IOException e) {
-			throw new KeePassDatabaseUnreadable("Could not open database file", e);
-		}
-	}
+            KeePassFile unprocessedKeepassFile = keePassDatabaseXmlParser.fromXml(new ByteArrayInputStream(decompressed));
+            new ProtectedValueProcessor().processProtectedValues(new DecryptionStrategy(protectedStringCrypto), unprocessedKeepassFile);
+            return new IconEnricher().enrichNodesWithIconData(unprocessedKeepassFile);
+        } catch (IOException e) {
+            throw new KeePassDatabaseUnreadable("Could not open database file", e);
+        }
+    }
 
-	/**
-	 * Gets the KeePassDatabase header.
-	 *
-	 * @return the database header
-	 */
-	public KeePassHeader getHeader() {
-		return keepassHeader;
-	}
+    /**
+     * Gets the KeePassDatabase header.
+     *
+     * @return the database header
+     */
+    public KeePassHeader getHeader() {
+        return keepassHeader;
+    }
 
-	/**
-	 * Encrypts a {@link KeePassFile} with the given password and writes it to
-	 * the given file location.
-	 * <p>
-	 * If the KeePassFile cannot be encrypted an exception will be thrown.
-	 *
-	 * @param keePassFile
-	 *            the keePass model which should be written
-	 * @param password
-	 *            the password to encrypt the database
-	 * @param keePassDatabaseFile
-	 *            the target location where the database file will be written
-	 * @see KeePassFile
-	 */
-	public static void write(KeePassFile keePassFile, String password, String keePassDatabaseFile) {
-		if (keePassDatabaseFile == null || keePassDatabaseFile.isEmpty()) {
-			throw new IllegalArgumentException(
-					"You must provide a non-empty path where the database should be written to.");
-		}
+    /**
+     * Encrypts a {@link KeePassFile} with the given password and writes it to
+     * the given file location.
+     * <p>
+     * If the KeePassFile cannot be encrypted an exception will be thrown.
+     *
+     * @param keePassFile
+     *            the keePass model which should be written
+     * @param password
+     *            the password to encrypt the database
+     * @param keePassDatabaseFile
+     *            the target location where the database file will be written
+     * @see KeePassFile
+     */
+    public static void write(KeePassFile keePassFile, String password, String keePassDatabaseFile) {
+        if (keePassDatabaseFile == null || keePassDatabaseFile.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "You must provide a non-empty path where the database should be written to.");
+        }
 
-		try {
-			write(keePassFile, password, new FileOutputStream(keePassDatabaseFile));
-		} catch (FileNotFoundException e) {
-			throw new KeePassDatabaseUnreadable("Could not find database file", e);
-		}
-	}
+        try {
+            write(keePassFile, password, new FileOutputStream(keePassDatabaseFile));
+        } catch (FileNotFoundException e) {
+            throw new KeePassDatabaseUnreadable("Could not find database file", e);
+        }
+    }
 
-	/**
-	 * Encrypts a {@link KeePassFile} with the given password and writes it to
-	 * the given stream.
-	 * <p>
-	 * If the KeePassFile cannot be encrypted an exception will be thrown.
-	 *
-	 * @param keePassFile
-	 *            the keePass model which should be written
-	 * @param password
-	 *            the password to encrypt the database
-	 * @param stream
-	 *            the target stream where the output will be written
-	 * @see KeePassFile
-	 *
-	 */
-	public static void write(KeePassFile keePassFile, String password, OutputStream stream) {
-		if (stream == null) {
-			throw new IllegalArgumentException("You must provide a stream to write to.");
-		}
+    /**
+     * Encrypts a {@link KeePassFile} with the given password and writes it to
+     * the given stream.
+     * <p>
+     * If the KeePassFile cannot be encrypted an exception will be thrown.
+     *
+     * @param keePassFile
+     *            the keePass model which should be written
+     * @param password
+     *            the password to encrypt the database
+     * @param stream
+     *            the target stream where the output will be written
+     * @see KeePassFile
+     *
+     */
+    public static void write(KeePassFile keePassFile, String password, OutputStream stream) {
+        if (stream == null) {
+            throw new IllegalArgumentException("You must provide a stream to write to.");
+        }
 
-		try {
-			if (!validateKeePassFile(keePassFile)) {
-				throw new KeePassDatabaseUnwriteable(
-						"The provided keePassFile is not valid. A valid keePassFile must contain of meta and root group and the root group must at least contain one group.");
-			}
+        try {
+            if (!validateKeePassFile(keePassFile)) {
+                throw new KeePassDatabaseUnwriteable(
+                        "The provided keePassFile is not valid. A valid keePassFile must contain of meta and root group and the root group must at least contain one group.");
+            }
 
-			KeePassHeader header = new KeePassHeader();
-			header.initialize();
+            KeePassHeader header = new KeePassHeader();
+            header.initialize();
 
-			byte[] passwordBytes = password.getBytes(UTF_8);
-			byte[] hashedPassword = Sha256.hash(passwordBytes);
+            byte[] passwordBytes = password.getBytes(UTF_8);
+            byte[] hashedPassword = Sha256.hash(passwordBytes);
 
-			// Marshall xml
-			ProtectedStringCrypto protectedStringCrypto = Salsa20.createInstance(header.getProtectedStreamKey());
-			new ProtectedValueProcessor().processProtectedValues(new EncryptionStrategy(protectedStringCrypto), keePassFile);
-			byte[] keePassFilePayload = new KeePassDatabaseXmlParser().toXml(keePassFile)
-					.toByteArray();
+            // Marshall xml
+            ProtectedStringCrypto protectedStringCrypto = Salsa20.createInstance(header.getProtectedStreamKey());
+            new ProtectedValueProcessor().processProtectedValues(new EncryptionStrategy(protectedStringCrypto), keePassFile);
+            byte[] keePassFilePayload = new KeePassDatabaseXmlParser().toXml(keePassFile)
+                    .toByteArray();
 
-			// Unzip
-			ByteArrayOutputStream streamToUnzip = new ByteArrayOutputStream();
-			GZIPOutputStream gzipOutputStream = new GZIPOutputStream(streamToUnzip);
-			gzipOutputStream.write(keePassFilePayload);
-			gzipOutputStream.close();
+            // Unzip
+            ByteArrayOutputStream streamToUnzip = new ByteArrayOutputStream();
+            GZIPOutputStream gzipOutputStream = new GZIPOutputStream(streamToUnzip);
+            gzipOutputStream.write(keePassFilePayload);
+            gzipOutputStream.close();
 
-			// Unhash
-			ByteArrayOutputStream streamToUnhashBlock = new ByteArrayOutputStream();
-			HashedBlockOutputStream hashBlockOutputStream = new HashedBlockOutputStream(streamToUnhashBlock);
-			hashBlockOutputStream.write(streamToUnzip.toByteArray());
-			hashBlockOutputStream.close();
+            // Unhash
+            ByteArrayOutputStream streamToUnhashBlock = new ByteArrayOutputStream();
+            HashedBlockOutputStream hashBlockOutputStream = new HashedBlockOutputStream(streamToUnhashBlock);
+            hashBlockOutputStream.write(streamToUnzip.toByteArray());
+            hashBlockOutputStream.close();
 
-			// Write Header
-			ByteArrayOutputStream streamToEncrypt = new ByteArrayOutputStream();
-			streamToEncrypt.write(header.getBytes());
-			streamToEncrypt.write(header.getStreamStartBytes());
+            // Write Header
+            ByteArrayOutputStream streamToEncrypt = new ByteArrayOutputStream();
+            streamToEncrypt.write(header.getBytes());
+            streamToEncrypt.write(header.getStreamStartBytes());
 
-			// Write Content
-			streamToEncrypt.write(streamToUnhashBlock.toByteArray());
+            // Write Content
+            streamToEncrypt.write(streamToUnhashBlock.toByteArray());
 
-			// Encrypt
-			byte[] encryptedDatabase = new Decrypter().encryptDatabase(hashedPassword, header,
-					streamToEncrypt.toByteArray());
+            // Encrypt
+            byte[] encryptedDatabase = new Decrypter().encryptDatabase(hashedPassword, header,
+                    streamToEncrypt.toByteArray());
 
-			// Write database to stream
-			stream.write(encryptedDatabase);
-		} catch (IOException e) {
-			throw new KeePassDatabaseUnwriteable("Could not write database file", e);
-		} finally {
-			if (stream != null) {
-				try {
-					stream.close();
-				} catch (IOException e) {
-					// Ignore
-				}
-			}
-		}
-	}
+            // Write database to stream
+            stream.write(encryptedDatabase);
+        } catch (IOException e) {
+            throw new KeePassDatabaseUnwriteable("Could not write database file", e);
+        } finally {
+            if (stream != null) {
+                try {
+                    stream.close();
+                } catch (IOException e) {
+                    // Ignore
+                }
+            }
+        }
+    }
 
-	private static boolean validateKeePassFile(KeePassFile keePassFile) {
-		if (keePassFile == null || keePassFile.getMeta() == null) {
-			return false;
-		}
+    private static boolean validateKeePassFile(KeePassFile keePassFile) {
+        if (keePassFile == null || keePassFile.getMeta() == null) {
+            return false;
+        }
 
-		if (keePassFile.getRoot() == null || keePassFile.getRoot().getGroups().isEmpty()) {
-			return false;
-		}
+        if (keePassFile.getRoot() == null || keePassFile.getRoot().getGroups().isEmpty()) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
 }

--- a/src/main/java/de/slackspace/openkeepass/xml/BooleanXmlAdapter.java
+++ b/src/main/java/de/slackspace/openkeepass/xml/BooleanXmlAdapter.java
@@ -9,28 +9,28 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
  */
 public class BooleanXmlAdapter extends XmlAdapter<String, Boolean> {
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see
-	 * javax.xml.bind.annotation.adapters.XmlAdapter#marshal(java.lang.Object)
-	 */
-	@Override
-	public String marshal(Boolean value) throws Exception {
-		if (value != null && value) {
-			return "True";
-		}
-		return "False";
-	}
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * javax.xml.bind.annotation.adapters.XmlAdapter#marshal(java.lang.Object)
+     */
+    @Override
+    public String marshal(Boolean value) throws Exception {
+        if (value != null && value) {
+            return "True";
+        }
+        return "False";
+    }
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see
-	 * javax.xml.bind.annotation.adapters.XmlAdapter#unmarshal(java.lang.Object)
-	 */
-	@Override
-	public Boolean unmarshal(String value) throws Exception {
-		return "true".equalsIgnoreCase(value);
-	}
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * javax.xml.bind.annotation.adapters.XmlAdapter#unmarshal(java.lang.Object)
+     */
+    @Override
+    public Boolean unmarshal(String value) throws Exception {
+        return "true".equalsIgnoreCase(value);
+    }
 }

--- a/src/main/java/de/slackspace/openkeepass/xml/KeePassDatabaseXmlParser.java
+++ b/src/main/java/de/slackspace/openkeepass/xml/KeePassDatabaseXmlParser.java
@@ -9,14 +9,14 @@ import de.slackspace.openkeepass.domain.KeePassFile;
 
 public class KeePassDatabaseXmlParser {
 
-	public KeePassFile fromXml(InputStream inputStream) {
-		return JAXB.unmarshal(inputStream, KeePassFile.class);
-	}
+    public KeePassFile fromXml(InputStream inputStream) {
+        return JAXB.unmarshal(inputStream, KeePassFile.class);
+    }
 
-	public ByteArrayOutputStream toXml(KeePassFile keePassFile) {
-		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-		JAXB.marshal(keePassFile, outputStream);
+    public ByteArrayOutputStream toXml(KeePassFile keePassFile) {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        JAXB.marshal(keePassFile, outputStream);
 
-		return outputStream;
-	}
+        return outputStream;
+    }
 }

--- a/src/main/java/de/slackspace/openkeepass/xml/KeyFileXmlParser.java
+++ b/src/main/java/de/slackspace/openkeepass/xml/KeyFileXmlParser.java
@@ -8,7 +8,7 @@ import de.slackspace.openkeepass.domain.KeyFile;
 
 public class KeyFileXmlParser {
 
-	public KeyFile fromXml(InputStream inputStream) {
-		return JAXB.unmarshal(inputStream, KeyFile.class);
-	}
+    public KeyFile fromXml(InputStream inputStream) {
+        return JAXB.unmarshal(inputStream, KeyFile.class);
+    }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00105 Tabulation characters should not be used. 
squid:S2184 Math operands should be cast before assignment.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00105
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2184
Please let me know if you have any questions.
George Kankava