### PR TITLE
Don't require a particular provider

### DIFF
--- a/src/main/java/de/slackspace/openkeepass/crypto/RandomGenerator.java
+++ b/src/main/java/de/slackspace/openkeepass/crypto/RandomGenerator.java
@@ -10,11 +10,9 @@ public class RandomGenerator {
 
     public RandomGenerator() {
         try {
-            random = SecureRandom.getInstance("SHA1PRNG", "SUN");
+            random = SecureRandom.getInstance("SHA1PRNG");
         } catch (NoSuchAlgorithmException e) {
             throw new UnsupportedOperationException("Algorithm 'SHA1PRNG' is unknown", e);
-        } catch (NoSuchProviderException e) {
-            throw new UnsupportedOperationException("Provider 'SUN' is unknown", e);
         }
     }
 

--- a/src/main/java/de/slackspace/openkeepass/crypto/Salsa20.java
+++ b/src/main/java/de/slackspace/openkeepass/crypto/Salsa20.java
@@ -29,7 +29,7 @@ public class Salsa20 implements ProtectedStringCrypto {
         byte[] salsaKey = Sha256.hash(protectedStreamKey);
 
         try {
-            salsa20Engine = Cipher.getInstance(SALSA20_ALGORITHM, BouncyCastleProvider.PROVIDER_NAME);
+            salsa20Engine = Cipher.getInstance(SALSA20_ALGORITHM);
             salsa20Engine.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(salsaKey, SALSA20_ALGORITHM), new IvParameterSpec(Hex.decode(SALSA20IV)));
         } catch (Exception e) {
             throw new UnsupportedOperationException("Could not find provider '" + SALSA20_ALGORITHM + "'", e);


### PR DESCRIPTION
From https://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html :

> Reminder: Cryptographic implementations in the JDK are distributed through several different providers ("Sun", "SunJSSE", "SunJCE", "SunRsaSign") for both historical reasons and by the types of services provided. General purpose applications SHOULD NOT request cryptographic services from specific providers. That is:

    getInstance("...", "SunJCE");  // not recommended
    // ... versus ...
    getInstance("...");            // recommended