### PR TITLE
Use relative paths and temp folders

### DIFF
--- a/src/test/java/de/slackspace/openkeepass/api/KeepassDatabaseReaderTest.java
+++ b/src/test/java/de/slackspace/openkeepass/api/KeepassDatabaseReaderTest.java
@@ -27,7 +27,7 @@ public class KeepassDatabaseReaderTest {
 
     @Test
     public void whenGettingEntriesByTitleShouldReturnMatchingEntries() throws FileNotFoundException {
-        FileInputStream file = new FileInputStream("target/test-classes/testDatabase.kdbx");
+        FileInputStream file = new FileInputStream(this.getClass().getClassLoader().getResource("testDatabase.kdbx").getPath());
 
         KeePassDatabase reader = KeePassDatabase.getInstance(file);
         KeePassFile database = reader.openDatabase("abcdefg");
@@ -38,7 +38,7 @@ public class KeepassDatabaseReaderTest {
 
     @Test
     public void whenGettingModifiedEntriesByTitleShouldReturnMatchingEntries() throws FileNotFoundException {
-        FileInputStream file = new FileInputStream("target/test-classes/testDatabaseModified.kdbx");
+        FileInputStream file = new FileInputStream(this.getClass().getClassLoader().getResource("testDatabaseModified.kdbx").getPath());
 
         KeePassDatabase reader = KeePassDatabase.getInstance(file);
         KeePassFile database = reader.openDatabase("abcdefg");
@@ -49,7 +49,7 @@ public class KeepassDatabaseReaderTest {
 
     @Test
     public void whenGettingEntriesByTitleButNothingMatchesShouldReturnNull() throws FileNotFoundException {
-        FileInputStream file = new FileInputStream("target/test-classes/testDatabase.kdbx");
+        FileInputStream file = new FileInputStream(this.getClass().getClassLoader().getResource("testDatabase.kdbx").getPath());
 
         KeePassDatabase reader = KeePassDatabase.getInstance(file);
         KeePassFile database = reader.openDatabase("abcdefg");
@@ -60,7 +60,7 @@ public class KeepassDatabaseReaderTest {
 
     @Test
     public void whenKeePassFileIsV2ShouldReadHeader() throws IOException {
-        FileInputStream file = new FileInputStream("target/test-classes/testDatabase.kdbx");
+        FileInputStream file = new FileInputStream(this.getClass().getClassLoader().getResource("testDatabase.kdbx").getPath());
 
         KeePassDatabase reader = KeePassDatabase.getInstance(file);
         KeePassHeader header = reader.getHeader();
@@ -84,7 +84,7 @@ public class KeepassDatabaseReaderTest {
 
     @Test
     public void whenPasswordIsValidShouldOpenKeepassFile() throws FileNotFoundException {
-        FileInputStream file = new FileInputStream("target/test-classes/testDatabase.kdbx");
+        FileInputStream file = new FileInputStream(this.getClass().getClassLoader().getResource("testDatabase.kdbx").getPath());
         KeePassDatabase reader = KeePassDatabase.getInstance(file);
 
         KeePassFile database = reader.openDatabase("abcdefg");
@@ -111,7 +111,7 @@ public class KeepassDatabaseReaderTest {
 
     @Test
     public void testIfPasswordsCanBeDecrypted() throws FileNotFoundException {
-        FileInputStream file = new FileInputStream("target/test-classes/fullBlownDatabase.kdbx");
+        FileInputStream file = new FileInputStream(this.getClass().getClassLoader().getResource("fullBlownDatabase.kdbx").getPath());
 
         KeePassDatabase reader = KeePassDatabase.getInstance(file);
         KeePassFile database = reader.openDatabase("123456");
@@ -127,7 +127,7 @@ public class KeepassDatabaseReaderTest {
 
     @Test
     public void whenEntryHasCustomPropertiesShouldReadCustomProperties() throws FileNotFoundException {
-        FileInputStream file = new FileInputStream("target/test-classes/fullBlownDatabase.kdbx");
+        FileInputStream file = new FileInputStream(this.getClass().getClassLoader().getResource("fullBlownDatabase.kdbx").getPath());
 
         KeePassDatabase reader = KeePassDatabase.getInstance(file);
         KeePassFile database = reader.openDatabase("123456");
@@ -143,7 +143,7 @@ public class KeepassDatabaseReaderTest {
 
     @Test
     public void whenPasswordOfEntryIsEmptyShouldReturnEmptyValue() throws FileNotFoundException {
-        FileInputStream file = new FileInputStream("target/test-classes/DatabaseWithEmptyPassword.kdbx");
+        FileInputStream file = new FileInputStream(this.getClass().getClassLoader().getResource("DatabaseWithEmptyPassword.kdbx").getPath());
 
         KeePassDatabase reader = KeePassDatabase.getInstance(file);
         KeePassFile database = reader.openDatabase("1234");
@@ -163,8 +163,8 @@ public class KeepassDatabaseReaderTest {
 
     @Test
     public void whenKeePassFileIsSecuredWithBinaryKeyFileShouldOpenKeePassFileWithKeyFile() throws FileNotFoundException {
-        FileInputStream keePassFile = new FileInputStream("target/test-classes/DatabaseWithBinaryKeyfile.kdbx");
-        FileInputStream keyFile = new FileInputStream("target/test-classes/0.png");
+        FileInputStream keePassFile = new FileInputStream(this.getClass().getClassLoader().getResource("DatabaseWithBinaryKeyfile.kdbx").getPath());
+        FileInputStream keyFile = new FileInputStream(this.getClass().getClassLoader().getResource("0.png").getPath());
 
         KeePassFile database = KeePassDatabase.getInstance(keePassFile).openDatabase(keyFile);
 
@@ -174,8 +174,8 @@ public class KeepassDatabaseReaderTest {
 
     @Test
     public void whenKeePassFileIsSecuredWithBinaryKeyFileAndPasswordShouldOpenKeePassFile() throws FileNotFoundException {
-        FileInputStream keePassFile = new FileInputStream("target/test-classes/DatabaseWithPasswordAndBinaryKeyfile.kdbx");
-        FileInputStream keyFile = new FileInputStream("target/test-classes/0.png");
+        FileInputStream keePassFile = new FileInputStream(this.getClass().getClassLoader().getResource("DatabaseWithPasswordAndBinaryKeyfile.kdbx").getPath());
+        FileInputStream keyFile = new FileInputStream(this.getClass().getClassLoader().getResource("0.png").getPath());
 
         KeePassFile database = KeePassDatabase.getInstance(keePassFile).openDatabase("1234", keyFile);
 
@@ -185,8 +185,8 @@ public class KeepassDatabaseReaderTest {
 
     @Test
     public void whenKeePassFileIsSecuredWithKeyFileShouldOpenKeePassFileWithKeyFile() throws FileNotFoundException {
-        FileInputStream keePassFile = new FileInputStream("target/test-classes/DatabaseWithKeyfile.kdbx");
-        FileInputStream keyFile = new FileInputStream("target/test-classes/DatabaseWithKeyfile.key");
+        FileInputStream keePassFile = new FileInputStream(this.getClass().getClassLoader().getResource("DatabaseWithKeyfile.kdbx").getPath());
+        FileInputStream keyFile = new FileInputStream(this.getClass().getClassLoader().getResource("DatabaseWithKeyfile.key").getPath());
 
         KeePassFile database = KeePassDatabase.getInstance(keePassFile).openDatabase(keyFile);
 
@@ -196,8 +196,8 @@ public class KeepassDatabaseReaderTest {
 
     @Test
     public void whenKeePassFileIsSecuredWithPasswordAndKeyFileShouldOpenKeePassFileWithPasswordAndKeyFile() throws FileNotFoundException {
-        FileInputStream keePassFile = new FileInputStream("target/test-classes/DatabaseWithPasswordAndKeyfile.kdbx");
-        FileInputStream keyFile = new FileInputStream("target/test-classes/DatabaseWithPasswordAndKeyfile.key");
+        FileInputStream keePassFile = new FileInputStream(this.getClass().getClassLoader().getResource("DatabaseWithPasswordAndKeyfile.kdbx").getPath());
+        FileInputStream keyFile = new FileInputStream(this.getClass().getClassLoader().getResource("DatabaseWithPasswordAndKeyfile.key").getPath());
 
         KeePassFile database = KeePassDatabase.getInstance(keePassFile).openDatabase("test123", keyFile);
 
@@ -207,36 +207,36 @@ public class KeepassDatabaseReaderTest {
 
     @Test(expected = KeePassDatabaseUnreadableException.class)
     public void whenKeePassFileIsSecuredWithPasswordAndKeyFileShouldNotOpenKeePassFileWithPassword() throws FileNotFoundException {
-        FileInputStream keePassFile = new FileInputStream("target/test-classes/DatabaseWithPasswordAndKeyfile.kdbx");
+        FileInputStream keePassFile = new FileInputStream(this.getClass().getClassLoader().getResource("DatabaseWithPasswordAndKeyfile.kdbx").getPath());
 
         KeePassDatabase.getInstance(keePassFile).openDatabase("test123");
     }
 
     @Test(expected = KeePassDatabaseUnreadableException.class)
     public void whenKeePassFileIsSecuredWithPasswordAndKeyFileShouldNotOpenKeePassFileWithKeyFile() throws FileNotFoundException {
-        FileInputStream keePassFile = new FileInputStream("target/test-classes/DatabaseWithPasswordAndKeyfile.kdbx");
-        FileInputStream keyFile = new FileInputStream("target/test-classes/DatabaseWithPasswordAndKeyfile.key");
+        FileInputStream keePassFile = new FileInputStream(this.getClass().getClassLoader().getResource("DatabaseWithPasswordAndKeyfile.kdbx").getPath());
+        FileInputStream keyFile = new FileInputStream(this.getClass().getClassLoader().getResource("DatabaseWithPasswordAndKeyfile.key").getPath());
 
         KeePassDatabase.getInstance(keePassFile).openDatabase(keyFile);
     }
 
     @Test
-    public void whenGettingInstanceByStringShouldOpenDatabase() {
-        KeePassFile database = KeePassDatabase.getInstance("target/test-classes/fullBlownDatabase.kdbx").openDatabase("123456");
+    public void whenGettingInstanceByStringShouldOpenDatabase() throws FileNotFoundException {
+        KeePassFile database = KeePassDatabase.getInstance(this.getClass().getClassLoader().getResource("fullBlownDatabase.kdbx").getPath()).openDatabase("123456");
         List<Entry> entries = database.getEntries();
         Assert.assertEquals("2f29047129b9e4c48f05d09907e52b9b", entries.get(0).getPassword());
     }
 
     @Test
     public void whenGettingInstanceByFileShouldOpenDatabase() {
-        KeePassFile database = KeePassDatabase.getInstance(new File("target/test-classes/fullBlownDatabase.kdbx")).openDatabase("123456");
+        KeePassFile database = KeePassDatabase.getInstance(new File(this.getClass().getClassLoader().getResource("fullBlownDatabase.kdbx").getPath())).openDatabase("123456");
         List<Entry> entries = database.getEntries();
         Assert.assertEquals("2f29047129b9e4c48f05d09907e52b9b", entries.get(0).getPassword());
     }
 
     @Test
     public void whenGettingEntriesFromKeeFoxShouldDecryptEntries() throws FileNotFoundException {
-        FileInputStream file = new FileInputStream("target/test-classes/KeeFoxDatabase.kdbx");
+        FileInputStream file = new FileInputStream(this.getClass().getClassLoader().getResource("KeeFoxDatabase.kdbx").getPath());
 
         KeePassDatabase reader = KeePassDatabase.getInstance(file);
         KeePassFile database = reader.openDatabase("abcd1234");
@@ -252,7 +252,7 @@ public class KeepassDatabaseReaderTest {
 
     @Test
     public void whenGettingEntryByUUIDShouldReturnFoundEntry() throws FileNotFoundException {
-        FileInputStream file = new FileInputStream("target/test-classes/testDatabase.kdbx");
+        FileInputStream file = new FileInputStream(this.getClass().getClassLoader().getResource("testDatabase.kdbx").getPath());
 
         KeePassDatabase reader = KeePassDatabase.getInstance(file);
         KeePassFile database = reader.openDatabase("abcdefg");
@@ -263,7 +263,7 @@ public class KeepassDatabaseReaderTest {
 
     @Test
     public void whenGettingGroupByUUIDShouldReturnFoundGroup() throws FileNotFoundException {
-        FileInputStream file = new FileInputStream("target/test-classes/testDatabase.kdbx");
+        FileInputStream file = new FileInputStream(this.getClass().getClassLoader().getResource("testDatabase.kdbx").getPath());
 
         KeePassDatabase reader = KeePassDatabase.getInstance(file);
         KeePassFile database = reader.openDatabase("abcdefg");

--- a/src/test/java/de/slackspace/openkeepass/api/KeepassDatabaseWriterTest.java
+++ b/src/test/java/de/slackspace/openkeepass/api/KeepassDatabaseWriterTest.java
@@ -48,7 +48,7 @@ public class KeepassDatabaseWriterTest {
 
     @Test
     public void whenWritingDatabaseFileShouldBeAbleToReadItAlso() throws FileNotFoundException {
-        FileInputStream fileInputStream = new FileInputStream("target/test-classes/testDatabase_decrypted.xml");
+        FileInputStream fileInputStream = new FileInputStream(this.getClass().getClassLoader().getResource("testDatabase_decrypted.xml").getPath());
         KeePassFile keePassFile = new KeePassDatabaseXmlParser().fromXml(fileInputStream);
         new ProtectedValueProcessor().processProtectedValues(new DecryptionStrategy(Salsa20.createInstance(protectedStreamKey)), keePassFile);
 
@@ -125,7 +125,7 @@ public class KeepassDatabaseWriterTest {
     @Test
     public void shouldModifiyGroupInKeePassFile() throws FileNotFoundException {
         String password = "123456";
-        KeePassDatabase keePassDb = KeePassDatabase.getInstance("target/test-classes/fullBlownDatabase.kdbx");
+        KeePassDatabase keePassDb = KeePassDatabase.getInstance(this.getClass().getClassLoader().getResource("fullBlownDatabase.kdbx").getPath());
         KeePassFile database = keePassDb.openDatabase(password);
 
         Group group = database.getGroupByName("test");
@@ -145,7 +145,7 @@ public class KeepassDatabaseWriterTest {
     @Test
     public void shouldModifyMetadataAndRenameGeneralNodeThenWriteAndReadDatabase() throws FileNotFoundException {
         String password = "abcdefg";
-        String originalDbFile = "target/test-classes/testDatabase.kdbx";
+        String originalDbFile = this.getClass().getClassLoader().getResource("testDatabase.kdbx").getPath();
         String modifiedDbFile = "target/test-classes/modifiedtestDatabase2.kdbx";
 
         KeePassFile database = KeePassDatabase.getInstance(originalDbFile).openDatabase(password);
@@ -198,9 +198,9 @@ public class KeepassDatabaseWriterTest {
     }
 
     @Test
-    public void shouldEnsureThatEntriesAreNotModifiedDuringWriting() {
+    public void shouldEnsureThatEntriesAreNotModifiedDuringWriting() throws FileNotFoundException {
         // open DB
-        final KeePassFile keePassFile = KeePassDatabase.getInstance("target/test-classes/testDatabase.kdbx").openDatabase("abcdefg");
+        final KeePassFile keePassFile = KeePassDatabase.getInstance(this.getClass().getClassLoader().getResource("testDatabase.kdbx").getPath()).openDatabase("abcdefg");
         Group generalGroup = keePassFile.getGroupByName("General");
 
         // add entry

--- a/src/test/java/de/slackspace/openkeepass/parser/KeePassDatabaseXmlParserTest.java
+++ b/src/test/java/de/slackspace/openkeepass/parser/KeePassDatabaseXmlParserTest.java
@@ -13,7 +13,9 @@ import java.util.UUID;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import de.slackspace.openkeepass.crypto.Salsa20;
 import de.slackspace.openkeepass.domain.Entry;
@@ -29,6 +31,9 @@ public class KeePassDatabaseXmlParserTest {
 
     private byte[] protectedStreamKey = ByteUtils.hexStringToByteArray("ec77a2169769734c5d26e5341401f8d7b11052058f8455d314879075d0b7e257");
     private static SimpleDateFormat dateFormatter;
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
 
     @BeforeClass
     public static void init() {
@@ -148,12 +153,14 @@ public class KeePassDatabaseXmlParserTest {
         KeePassDatabaseXmlParser parser = new KeePassDatabaseXmlParser();
         KeePassFile keePassFile = parser.fromXml(fileInputStream);
 
+        String testDatabase_decrypted2 = tempFolder.newFile("testDatabase_decrypted2.xml").getPath();
+
         ByteArrayOutputStream outputStream = parser.toXml(keePassFile);
-        OutputStream fileOutputStream = new FileOutputStream("target/test-classes/testDatabase_decrypted2.xml");
+        OutputStream fileOutputStream = new FileOutputStream(testDatabase_decrypted2);
         outputStream.writeTo(fileOutputStream);
 
         // Read written file
-        FileInputStream writtenInputStream = new FileInputStream("target/test-classes/testDatabase_decrypted2.xml");
+        FileInputStream writtenInputStream = new FileInputStream(testDatabase_decrypted2);
         KeePassFile writtenKeePassFile = parser.fromXml(writtenInputStream);
         new ProtectedValueProcessor().processProtectedValues(new DecryptionStrategy(Salsa20.createInstance(protectedStreamKey)), writtenKeePassFile);
 

--- a/src/test/java/de/slackspace/openkeepass/parser/KeePassDatabaseXmlParserTest.java
+++ b/src/test/java/de/slackspace/openkeepass/parser/KeePassDatabaseXmlParserTest.java
@@ -133,7 +133,7 @@ public class KeePassDatabaseXmlParserTest {
     }
 
     private KeePassFile parseKeePassXml() throws FileNotFoundException {
-        FileInputStream fileInputStream = new FileInputStream("target/test-classes/testDatabase_decrypted.xml");
+        FileInputStream fileInputStream = new FileInputStream(this.getClass().getClassLoader().getResource("testDatabase_decrypted.xml").getPath());
         KeePassFile keePassFile = new KeePassDatabaseXmlParser().fromXml(fileInputStream);
 
         new ProtectedValueProcessor().processProtectedValues(new DecryptionStrategy(Salsa20.createInstance(protectedStreamKey)), keePassFile);
@@ -144,7 +144,7 @@ public class KeePassDatabaseXmlParserTest {
     @Test
     public void whenWritingKeePassFileShouldBeAbleToReadItAgain() throws IOException {
         // Read decrypted and write again
-        FileInputStream fileInputStream = new FileInputStream("target/test-classes/testDatabase_decrypted.xml");
+        FileInputStream fileInputStream = new FileInputStream(this.getClass().getClassLoader().getResource("testDatabase_decrypted.xml").getPath());
         KeePassDatabaseXmlParser parser = new KeePassDatabaseXmlParser();
         KeePassFile keePassFile = parser.fromXml(fileInputStream);
 

--- a/src/test/java/de/slackspace/openkeepass/parser/KeyFileXmlParserTest.java
+++ b/src/test/java/de/slackspace/openkeepass/parser/KeyFileXmlParserTest.java
@@ -14,7 +14,7 @@ public class KeyFileXmlParserTest {
 
     @Test
     public void whenInputIsKeyFileShouldParseFileAndReturnCorrectData() throws IOException {
-        FileInputStream fileInputStream = new FileInputStream("target/test-classes/DatabaseWithKeyfile.key");
+        FileInputStream fileInputStream = new FileInputStream(this.getClass().getClassLoader().getResource("DatabaseWithKeyfile.key").getPath());
         byte[] keyFileContent = StreamUtils.toByteArray(fileInputStream);
 
         KeyFile keyFile = new KeyFileXmlParser().fromXml(keyFileContent);


### PR DESCRIPTION
The tests fail if they are used in a different environment (as submodule in Android Studio as example), since the paths are different.
So the solution is to use paths relative to the class for reading, and the tempfolder rule provided by junit for writing.